### PR TITLE
Fix README.md deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ npx wrangler login
 Deploy the Worker
 
 ```bash
-yarn run deploy
+yarn && yarn run deploy
 ```
 
 Set your ETH RPC environment variable


### PR DESCRIPTION
npx wrangler will not install wrangler as a dev dependency and hence when the user then calls it without a reference in the next command

```
yarn run deploy
yarn run v1.22.18
warning ../../package.json: No license field
$ wrangler deploy
/bin/sh: wrangler: command not found
error Command failed with exit code 127.
```