### PR TITLE
Add strict avatar fallback opt-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ By default, all endpoints are cached for 10 minutes, then serve a stale response
   - Params (all optional):
     - `width` - width of the avatar (default: 256)
     - `height` - height of the avatar (default: 256)
-    - `fallback` - image URL to use if the ENS name has no avatar
+    - `fallback` - image URL to use if the ENS name has no avatar. Set to `none` to return a 404 instead of a fallback image.
 - POST `/batch/names` - Resolve a list of addresses from ENS names
   - Body:
     - `names` - array of ENS names

--- a/src/handlers/avatar.ts
+++ b/src/handlers/avatar.ts
@@ -8,7 +8,7 @@ const schema = z.object({
   name: z.string(),
   width: z.coerce.number().optional(),
   height: z.coerce.number().optional(),
-  fallback: z.string().url().optional(),
+  fallback: z.union([z.literal('none'), z.string().url()]).optional(),
 });
 
 export async function handleAvatar(request: IRequest, env: Env, ctx: ExecutionContext) {

--- a/src/lib/avt-fallback.ts
+++ b/src/lib/avt-fallback.ts
@@ -11,7 +11,6 @@ const avatar = `
   </svg>
 `;
 
-// return 404 status but still send the fallback avatar
 export async function fallbackResponse(
   ctx: ExecutionContext,
   cache: Cache,
@@ -20,7 +19,14 @@ export async function fallbackResponse(
 ) {
   let res: Response;
 
-  if (fallback) {
+  if (fallback === 'none') {
+    res = new Response(null, {
+      status: 404,
+      headers: {
+        'Cache-Control': 'no-store',
+      },
+    });
+  } else if (fallback) {
     res = await fetch(fallback);
     res = new Response(res.body, res);
   } else {


### PR DESCRIPTION
## Summary
- Allow /avatar/:name?fallback=none to opt out of fallback images
- Return a bare 404 with no-store caching when strict fallback mode has no usable avatar
- Document the new fallback=none behavior

## Test
- node_modules/.bin/tsc --noEmit