### PR TITLE
Enhance avatar caching strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ By default, all endpoints are cached for 10 minutes, then serve a stale response
   - Params (all optional):
     - `width` - width of the avatar (default: 256)
     - `height` - height of the avatar (default: 256)
-    - `fallback` - image URL to use if the ENS name has no avatar
+    - `fallback` - image URL to use if the ENS name has no avatar. Set to `none` to return a 404 instead of a fallback image.
 - POST `/batch/names` - Resolve a list of addresses from ENS names
   - Body:
     - `names` - array of ENS names

--- a/README.md
+++ b/README.md
@@ -5,7 +5,14 @@
 
 Cloudflare Worker that provides a simple API for fetching ENS profiles and avatars. Built with [ENSjs](https://www.npmjs.com/package/@ensdomains/ensjs), inspired by [v3xlabs/enstate](https://github.com/v3xlabs/enstate).
 
-By default, all endpoints are cached for 10 minutes, then serve a stale response within the following 50 minutes while refreshing the cache in the background. Adjust these settings [here](src/lib/utils.ts#L79-L96). Avatars are cached for longer in most cases.
+By default, profile and batch endpoints are cached for 10 minutes, then serve a stale response within the following 50 minutes while refreshing the cache in the background. Adjust these settings [here](src/lib/utils.ts#L79-L96).
+
+Avatar endpoints use a separate cache policy:
+
+- Live ENS avatars are cached for 24 hours, then serve stale responses for up to 1 week while refreshing in the background.
+- Default and custom fallback avatars are cached for 1 hour, then serve stale responses for up to 24 hours while refreshing in the background.
+- `fallback=none` returns an uncached 404 when no avatar is found.
+- Avatar cache entries vary by the full request URL, so distinct `width`, `height`, and `fallback` params are cached independently.
 
 ## Endpoints:
 

--- a/src/handlers/avatar.ts
+++ b/src/handlers/avatar.ts
@@ -8,7 +8,7 @@ const schema = z.object({
   name: z.string(),
   width: z.coerce.number().optional(),
   height: z.coerce.number().optional(),
-  fallback: z.string().url().optional(),
+  fallback: z.union([z.literal('none'), z.string().url()]).optional(),
 });
 
 export async function handleAvatar(request: IRequest, env: Env, ctx: ExecutionContext) {

--- a/src/handlers/avatar.ts
+++ b/src/handlers/avatar.ts
@@ -1,7 +1,12 @@
 import { IRequest } from 'itty-router';
 import { z } from 'zod';
 
-import { fallbackResponse } from '../lib/avt-fallback';
+import {
+  cacheAvatarResponse,
+  fallbackResponse,
+  LIVE_AVATAR_CACHE_CONTROL,
+  withCacheControl,
+} from '../lib/avt-fallback';
 import { checkCache, getPublicClient } from '../lib/utils';
 
 const schema = z.object({
@@ -47,7 +52,7 @@ export async function handleAvatar(request: IRequest, env: Env, ctx: ExecutionCo
   const res = await fetch(ensAvatar, {
     headers: request.headers,
     cf: {
-      cacheTtl: 3600,
+      cacheTtl: 86400,
       cacheEverything: true,
       image: {
         width: width || height || 256,
@@ -59,8 +64,8 @@ export async function handleAvatar(request: IRequest, env: Env, ctx: ExecutionCo
 
   // Sometimes OpenSea returns a 304 Not Modified status which is not technically `ok`, but we should still return.
   if ((res.status >= 200 && res.status < 400) || res.redirected) {
-    ctx.waitUntil(cache.put(cacheKey, res.clone()));
-    return new Response(res.body, res);
+    const response = withCacheControl(res, LIVE_AVATAR_CACHE_CONTROL);
+    return cacheAvatarResponse(ctx, cache, cacheKey, response);
   } else {
     console.log({ res: res.status, ok: res.ok });
     return fallbackResponse(ctx, cache, cacheKey, fallback);

--- a/src/lib/avt-fallback.ts
+++ b/src/lib/avt-fallback.ts
@@ -11,7 +11,6 @@ const avatar = `
   </svg>
 `;
 
-// return 404 status but still send the fallback avatar
 export async function fallbackResponse(
   ctx: ExecutionContext,
   cache: Cache,
@@ -20,7 +19,14 @@ export async function fallbackResponse(
 ) {
   let res: Response;
 
-  if (fallback) {
+  if (fallback === 'none') {
+    res = new Response(null, {
+      status: 404,
+      headers: {
+        'Cache-Control': 'no-store',
+      },
+    });
+  } else if (fallback) {
     res = await fetch(fallback);
     res = new Response(res.body, res);
   } else {

--- a/src/lib/avt-fallback.ts
+++ b/src/lib/avt-fallback.ts
@@ -11,6 +11,28 @@ const avatar = `
   </svg>
 `;
 
+export const LIVE_AVATAR_CACHE_CONTROL =
+  'public, max-age=86400, stale-while-revalidate=604800';
+
+export const FALLBACK_AVATAR_CACHE_CONTROL =
+  'public, max-age=3600, stale-while-revalidate=86400';
+
+export function withCacheControl(response: Response, cacheControl: string) {
+  const res = new Response(response.body, response);
+  res.headers.set('Cache-Control', cacheControl);
+  return res;
+}
+
+export function cacheAvatarResponse(
+  ctx: ExecutionContext,
+  cache: Cache,
+  cacheKey: Request,
+  response: Response
+) {
+  ctx.waitUntil(cache.put(cacheKey, response.clone()));
+  return response;
+}
+
 export async function fallbackResponse(
   ctx: ExecutionContext,
   cache: Cache,
@@ -20,7 +42,7 @@ export async function fallbackResponse(
   let res: Response;
 
   if (fallback === 'none') {
-    res = new Response(null, {
+    return new Response(null, {
       status: 404,
       headers: {
         'Cache-Control': 'no-store',
@@ -28,15 +50,15 @@ export async function fallbackResponse(
     });
   } else if (fallback) {
     res = await fetch(fallback);
-    res = new Response(res.body, res);
+    res = withCacheControl(res, FALLBACK_AVATAR_CACHE_CONTROL);
   } else {
     res = new Response(avatar, {
       headers: {
         'Content-Type': 'image/svg+xml',
-        'Cache-Control': 'public, max-age=600, stale-while-revalidate=3000',
+        'Cache-Control': FALLBACK_AVATAR_CACHE_CONTROL,
       },
     });
   }
 
-  return res;
+  return cacheAvatarResponse(ctx, cache, cacheKey, res);
 }


### PR DESCRIPTION
Enhances avatar caching so live ENS avatars, fallback avatars, and `fallback=none` responses each have explicit cache behavior.

- Live avatars now cache for 24 hours with 1 week `stale-while-revalidate`, and Cloudflare image transform caching is aligned to 24 hours.
- Default/custom fallback avatars now cache for 1 hour with 24 hours `stale-while-revalidate`.
- `fallback=none` continues to return an uncached `404`.
- README now documents avatar cache behavior separately from JSON endpoint caching.