### PR TITLE
Add ENS avatar + imgproxy service scaffold

### DIFF
--- a/avatar-proxy-service/Dockerfile
+++ b/avatar-proxy-service/Dockerfile
@@ -1,0 +1,23 @@
+FROM node:22-alpine AS api-base
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install --omit=dev
+COPY src ./src
+COPY entrypoint.sh ./entrypoint.sh
+RUN chmod +x ./entrypoint.sh
+
+FROM darthsim/imgproxy:latest
+USER root
+RUN apk add --no-cache nodejs npm
+WORKDIR /app
+COPY --from=api-base /app /app
+
+ENV PORT=3000
+ENV IMGPROXY_BIND=0.0.0.0:8080
+ENV IMGPROXY_LOCAL_FILESYSTEM_ROOT=/tmp
+ENV IMGPROXY_USE_ETAG=true
+ENV IMGPROXY_TTL=31536000
+ENV IMGPROXY_MAX_SRC_RESOLUTION=50
+
+EXPOSE 3000 8080
+CMD ["/app/entrypoint.sh"]

--- a/avatar-proxy-service/README.md
+++ b/avatar-proxy-service/README.md
@@ -1,0 +1,75 @@
+# ENS Avatar + imgproxy service plan
+
+This folder is a **new add-on service** (no existing app code removed) that combines:
+
+1. ENS avatar lookup over Ethereum RPC via `viem` (`getEnsAvatar`).
+2. Local image optimization via `imgproxy` in the same container.
+
+## Request flow
+
+1. `GET /avatar/:name?width=256&height=256`
+2. API checks cache for ENS avatar URL (not transformed image bytes).
+3. On cache miss, API calls `client.getEnsAvatar({ name })` using `ETH_RPC`.
+4. API builds an imgproxy URL and fetches optimized output from local `imgproxy`.
+5. API returns optimized bytes + cache headers.
+
+## Caching strategy
+
+Use **two cache layers** with clear responsibilities:
+
+### Layer 1: ENS avatar URL cache (entrypoint cache, before imgproxy)
+
+Purpose: avoid unnecessary Ethereum RPC reads.
+
+- Key: `ens:avatar:url:{name}`
+- Value: source avatar URL returned from ENS text records / NFT metadata resolution.
+- TTL suggestion: 1 hour default (`AVATAR_URL_CACHE_TTL_SECONDS=3600`), tune to 5-30 min if you need faster refresh.
+- Store:
+  - Local LRU in-process cache (fast, cheap).
+  - Optional Redis shared cache (`REDIS_URL`) so multiple replicas avoid duplicate RPC calls.
+
+Why this layer matters:
+
+- imgproxy caches transformed bytes by source URL + transform options, but **it does not know ENS names**.
+- Without this layer, every cold request still needs an RPC lookup even if transforms are cached.
+
+### Layer 2: imgproxy image cache
+
+Purpose: avoid repeated image resize/encode and repeated upstream source downloads.
+
+- imgproxy handles transformed image caching and revalidation.
+- Set `IMGPROXY_TTL` high (for example 1 year) and rely on source URL changes when users update avatars.
+- You can add a CDN in front (Railway edge/proxy/CDN) for global caching of final bytes.
+
+## Why not only imgproxy cache?
+
+If you only cache at imgproxy:
+
+- You still pay RPC latency/cost for name->avatar resolution on misses at your API entrypoint.
+- Burst traffic for the same ENS name across replicas can trigger duplicate `getEnsAvatar` calls.
+
+Recommendation: keep both layers. This gives the best cost profile.
+
+## Railway deployment notes
+
+- Deploy `avatar-proxy-service/Dockerfile` as a dedicated service.
+- Required env vars:
+  - `ETH_RPC` (required)
+  - `REDIS_URL` (optional but recommended for replicas)
+  - `IMGPROXY_KEY`, `IMGPROXY_SALT` (recommended for signed URLs later)
+  - `PORT` (Railway injects this)
+- Scale via replicas by region; Redis should be shared (or region-local) to preserve entrypoint cache benefit.
+
+## Suggested roadmap
+
+1. **MVP** (this scaffold): endpoint + local LRU + local imgproxy process.
+2. **Production hardening**:
+   - Add request signing for imgproxy paths (remove `/insecure`).
+   - Add allowlist / SSRF protections for source hosts.
+   - Add metrics: RPC hit/miss, cache hit ratio, imgproxy status codes.
+3. **Performance**:
+   - Enable Redis for cross-replica cache sharing.
+   - Put a CDN in front of `/avatar/:name` for byte-level caching near users.
+4. **Monorepo migration later**:
+   - Move this folder into `apps/avatar-proxy` when you reorganize.
+

--- a/avatar-proxy-service/entrypoint.sh
+++ b/avatar-proxy-service/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+set -eu
+
+: "${IMGPROXY_KEY:=}" 
+: "${IMGPROXY_SALT:=}"
+
+imgproxy &
+IMGPROXY_PID=$!
+
+node src/server.js &
+API_PID=$!
+
+trap 'kill ${IMGPROXY_PID} ${API_PID}' INT TERM
+wait -n ${IMGPROXY_PID} ${API_PID}

--- a/avatar-proxy-service/package.json
+++ b/avatar-proxy-service/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "ens-avatar-proxy-service",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "node src/server.js"
+  },
+  "dependencies": {
+    "express": "^4.19.2",
+    "ioredis": "^5.4.1",
+    "lru-cache": "^10.2.2",
+    "viem": "^2.21.32"
+  }
+}

--- a/avatar-proxy-service/src/server.js
+++ b/avatar-proxy-service/src/server.js
@@ -1,0 +1,110 @@
+import express from 'express';
+import { LRUCache } from 'lru-cache';
+import Redis from 'ioredis';
+import { createPublicClient, http } from 'viem';
+import { mainnet } from 'viem/chains';
+
+const app = express();
+
+const PORT = Number(process.env.PORT || 3000);
+const IMGPROXY_URL = process.env.IMGPROXY_URL || 'http://127.0.0.1:8080';
+const ETH_RPC = process.env.ETH_RPC;
+const CACHE_TTL_SECONDS = Number(process.env.AVATAR_URL_CACHE_TTL_SECONDS || 3600);
+const REDIS_URL = process.env.REDIS_URL;
+
+if (!ETH_RPC) {
+  throw new Error('ETH_RPC is required');
+}
+
+const client = createPublicClient({ chain: mainnet, transport: http(ETH_RPC) });
+const memoryCache = new LRUCache({ max: 5000, ttl: CACHE_TTL_SECONDS * 1000 });
+const redis = REDIS_URL ? new Redis(REDIS_URL, { lazyConnect: true }) : null;
+
+async function getCachedAvatarUrl(name) {
+  const key = `ens:avatar:url:${name.toLowerCase()}`;
+  const inMemory = memoryCache.get(key);
+
+  if (inMemory) return inMemory;
+
+  if (redis) {
+    try {
+      if (redis.status === 'wait') await redis.connect();
+      const cached = await redis.get(key);
+      if (cached) {
+        memoryCache.set(key, cached);
+        return cached;
+      }
+    } catch {}
+  }
+
+  const avatarUrl = await client.getEnsAvatar({ name });
+  if (!avatarUrl) return null;
+
+  memoryCache.set(key, avatarUrl);
+
+  if (redis) {
+    try {
+      await redis.set(key, avatarUrl, 'EX', CACHE_TTL_SECONDS);
+    } catch {}
+  }
+
+  return avatarUrl;
+}
+
+function base64urlEncode(value) {
+  return Buffer.from(value).toString('base64url');
+}
+
+app.get('/healthz', (_, res) => {
+  res.status(200).json({ ok: true });
+});
+
+app.get('/avatar/:name', async (req, res) => {
+  const { name } = req.params;
+  const width = Number(req.query.width || 256);
+  const height = Number(req.query.height || 256);
+
+  if (!name?.endsWith('.eth')) {
+    return res.status(400).json({ error: 'name must be a valid .eth name' });
+  }
+
+  if (Number.isNaN(width) || Number.isNaN(height) || width <= 0 || height <= 0) {
+    return res.status(400).json({ error: 'width/height must be positive integers' });
+  }
+
+  try {
+    const avatarUrl = await getCachedAvatarUrl(name);
+
+    if (!avatarUrl) {
+      return res.status(404).json({ error: 'no ENS avatar found' });
+    }
+
+    const encoded = base64urlEncode(avatarUrl);
+    const processing = `rs:fill:${width}:${height}:0/g:sm`;
+    const imgproxyPath = `/insecure/${processing}/plain/${encoded}`;
+    const upstream = `${IMGPROXY_URL}${imgproxyPath}`;
+
+    const upstreamResponse = await fetch(upstream, {
+      headers: {
+        accept: req.headers.accept || 'image/*'
+      }
+    });
+
+    if (!upstreamResponse.ok) {
+      const text = await upstreamResponse.text();
+      return res.status(upstreamResponse.status).send(text);
+    }
+
+    res.setHeader('Content-Type', upstreamResponse.headers.get('content-type') || 'image/webp');
+    res.setHeader('Cache-Control', 'public, max-age=300, s-maxage=300, stale-while-revalidate=86400');
+
+    const bytes = Buffer.from(await upstreamResponse.arrayBuffer());
+    return res.status(200).send(bytes);
+  } catch (error) {
+    return res.status(500).json({ error: error.message || 'internal error' });
+  }
+});
+
+app.listen(PORT, () => {
+  console.log(`avatar proxy listening on :${PORT}`);
+});


### PR DESCRIPTION
### Motivation
- Provide a self-hosted avatar pipeline that resolves ENS avatars via Ethereum RPC and performs image transformation with `imgproxy` to avoid Cloudflare Image Transformation costs. 
- Keep the existing Cloudflare Worker code untouched by adding an isolated service that can be deployed independently. 
- Reduce RPC load by caching the ENS name→avatar URL mapping to prevent repeated `getEnsAvatar` calls across bursts and replicas.

### Description
- Add a new root-level service in `avatar-proxy-service/` with `src/server.js` that exposes `GET /avatar/:name` and resolves ENS avatars using `viem` (`getEnsAvatar`).
- Implement an entrypoint cache for ENS avatar URLs using an in-process LRU (`lru-cache`) and an optional Redis layer (`ioredis`) with TTL configurable via `AVATAR_URL_CACHE_TTL_SECONDS`.
- Proxy transformation requests to a local `imgproxy` process by building a `plain` base64url-encoded input path and returning the optimized bytes with HTTP cache headers.
- Add a Railway-friendly `Dockerfile` and `entrypoint.sh` that run both `imgproxy` (from `darthsim/imgproxy`) and the Node API in one container, plus `package.json` and a `README.md` documenting the two-layer caching strategy and deployment notes.

### Testing
- Ran `node --check avatar-proxy-service/src/server.js` which succeeded (no syntax errors reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e19e6e4448333968923eb6fe492e3)